### PR TITLE
Setup service discovery between master and nodes

### DIFF
--- a/nubis/puppet/discovery.pp
+++ b/nubis/puppet/discovery.pp
@@ -1,7 +1,7 @@
-include nubis_discovery
-
-# Switch to MC port once working
-nubis::discovery::service { $project_name:
-  tcp      => '443',
+file { '/etc/consul/svc-kubernetes.json':
+  ensure => file,
+  owner  => root,
+  group  => root,
+  mode   => '0644',
+  source => 'puppet:///nubis/files/svc-kubernetes.json'
 }
-

--- a/nubis/puppet/files/svc-kubernetes.json
+++ b/nubis/puppet/files/svc-kubernetes.json
@@ -1,14 +1,16 @@
 {
-  "service": "kubernetes",
-  "tags": [
-    "kubernetes",
-    "%%PURPOSE%%"
-  ],
-  "port": "10255",
-  "check": {
-    "name": "kubelet check",
-    "notes": "Check kubelet health endpoint, kubelets are the most basic componenet and will be on every node in the cluster",
-    "http": "http://localhost:10255/healthz",
-    "interval": "60s"
+  "service": {
+    "name": "kubernetes",
+    "tags": [
+      "kubernetes",
+      "%%PURPOSE%%"
+    ],
+    "port": 10255,
+    "check": {
+      "name": "kubelet check",
+      "notes": "Check kubelet health endpoint, kubelets are the most basic componenet and will be on every node in the cluster",
+      "http": "http://localhost:10255/healthz",
+      "interval": "60s"
+    }
   }
 }

--- a/nubis/puppet/files/svc-kubernetes.json
+++ b/nubis/puppet/files/svc-kubernetes.json
@@ -1,0 +1,14 @@
+{
+  "service": "kubernetes",
+  "tags": [
+    "kubernetes",
+    "%%PURPOSE%%"
+  ],
+  "port": "10255",
+  "check": {
+    "name": "kubelet check",
+    "notes": "Check kubelet health endpoint, kubelets are the most basic componenet and will be on every node in the cluster",
+    "http": "http://localhost:10255/healthz",
+    "interval": "60s"
+  }
+}


### PR DESCRIPTION
Set up a basic way to split up node and masters, however I think a better way to check for master is to check the api server health and kubelet for nodes

This is a good start though. Fixes #13