### PR TITLE
Fix upstream DNS resolution

### DIFF
--- a/nubis/puppet/dnsmasq.pp
+++ b/nubis/puppet/dnsmasq.pp
@@ -1,0 +1,11 @@
+class { 'dnsmasq':
+  reload_resolvconf => false,
+  restart           => false,
+  service_ensure    => 'stopped',
+}
+
+dnsmasq::dnsserver { 'consul':
+  domain => 'consul',
+  ip     => '127.0.0.1',
+  port   => '8600'
+}

--- a/nubis/puppet/files/kubernetes-startup
+++ b/nubis/puppet/files/kubernetes-startup
@@ -10,4 +10,9 @@ cat << EOF | tee /etc/consul/bind.json
   "bind_addr": "${IP_ADDR}"
 }
 EOF
+
+cat << EOF | tee /etc/resolvconf/resolv.conf.d
+# Added to help kube-dns find a good forwarder
+nameserver ${IP_ADDR}
+EOF
 fi


### PR DESCRIPTION
- make dnsmasq listen on all interfaces
- inject our public ip in /etc/resolv.conf for kube-dns to scrape

Fixes #46