### PR TITLE
Use Kops channels to create a NodePort for Kubernetes Dashboard

### DIFF
--- a/nubis/terraform/addons.tf
+++ b/nubis/terraform/addons.tf
@@ -1,0 +1,21 @@
+# These need to not be too long
+locals {
+  dashboard_etag = "${substr(md5(file("${path.module}/files/addons/dashboard-sso/manifest.yaml")), 0, 6)}"
+  addons_etag    = "${local.dashboard_etag}"
+}
+
+resource "aws_s3_bucket_object" "nubis_addon" {
+  bucket       = "${module.kops_bucket.name}"
+  key          = "kubernetes.${module.info.hosted_zone_name}/addons/nubis/${local.addons_etag}/addon.yaml"
+  source       = "${path.module}/files/addons/addon.yaml"
+  etag         = "${md5(file("${path.module}/files/addons/addon.yaml"))}"
+  content_type = "text/yaml"
+}
+
+resource "aws_s3_bucket_object" "dashboard_manifest" {
+  bucket       = "${module.kops_bucket.name}"
+  key          = "kubernetes.${module.info.hosted_zone_name}/addons/nubis/${local.addons_etag}/dashboard-sso/manifest.yaml"
+  source       = "${path.module}/files/addons/dashboard-sso/manifest.yaml"
+  etag         = "${local.dashboard_etag}"
+  content_type = "text/yaml"
+}

--- a/nubis/terraform/files/addons/addon.yaml
+++ b/nubis/terraform/files/addons/addon.yaml
@@ -1,0 +1,11 @@
+kind: Addons
+metadata:
+  name: nubis
+spec:
+  addons:
+  - version: 1.0.0
+    id: nubis.00
+    name: kubernetes-dashboard-sso.nubis.addons.k8s.io
+    selector:
+      k8s-addon: kubernetes-dashboard-sso.nubis.addons.k8s.io
+    manifest: dashboard-sso/manifest.yaml

--- a/nubis/terraform/files/addons/dashboard-sso/manifest.yaml
+++ b/nubis/terraform/files/addons/dashboard-sso/manifest.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-sso
+  namespace: kube-system
+spec:
+  ports:
+  - nodePort: 31443
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard
+  type: NodePort

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -55,6 +55,9 @@ module "kops_cluster" {
   addons = [
     "manifest: monitoring-standalone",
     "manifest: kubernetes-dashboard",
+
+    # This value need to *not* be computed, TF issue otherwise
+    "manifest: s3://${module.kops_bucket.name}/kubernetes.${module.info.hosted_zone_name}/addons/nubis/${local.addons_etag}/addon.yaml",
   ]
 
   aws-region = "${var.region}"
@@ -136,6 +139,17 @@ resource "aws_security_group" "kubernetes" {
 
     security_groups = [
       "${module.info.monitoring_security_group}",
+    ]
+  }
+
+  # We are exposing the Kubernetes Dashboard on all nodes via this port
+  ingress {
+    from_port = 31443
+    to_port   = 31443
+    protocol  = "tcp"
+
+    security_groups = [
+      "${module.info.sso_security_group}",
     ]
   }
 


### PR DESCRIPTION
Enabled on static TCP/31443

Fixes #49