### PR TITLE
Official projects don't need to use the git sha in their revisions

### DIFF
--- a/nubis/builder/project.json
+++ b/nubis/builder/project.json
@@ -7,7 +7,7 @@
     "deregister": "true",
     "project_description": "Kubernetes image for runing in Nubis",
     "project_name": "nubis-kubernetes",
-    "project_version": "v2.3.0-dev_{{env `GIT_COMMIT_SHA`}}",
+    "project_version": "v2.3.0-dev",
     "source_ami_project_version": "v2.3.0-dev"
   }
 }


### PR DESCRIPTION
Fixes #63