### PR TITLE
Set max-minion to 2x what min-minion is set at

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -112,6 +112,7 @@ module "kops_cluster" {
   minion-additional-user-data = "${data.template_file.userdata_node.rendered}"
   minion-update-interval      = 4
   min-minions                 = "${var.kubernetes_node_minimum}"
+  max-minions                 = "${2 * var.kubernetes_node_minimum}"
 }
 
 resource "aws_security_group" "kubernetes" {


### PR DESCRIPTION
Otherwise, we can't go higher than 3 minions (max-minion defaults to 3)

Fixes #69