### PR TITLE
Move enabled to nubis-deploy

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -53,8 +53,6 @@ module "kops_cluster" {
   #source  = "../aws/cluster"
   source = "github.com/tinnightcap/karch//aws/cluster?ref=nubis-compat"
 
-  enabled = "${var.enabled}"
-
   kubernetes-version = "v1.9.7"
 
   addons = [
@@ -116,7 +114,6 @@ module "kops_cluster" {
 }
 
 resource "aws_security_group" "kubernetes" {
-  count = "${var.enabled}"
 
   name_prefix = "${var.service_name}-${var.arena}-${var.environment}-ssh-"
 

--- a/nubis/terraform/variables.tf
+++ b/nubis/terraform/variables.tf
@@ -1,7 +1,3 @@
-variable "enabled" {
-  default = "1"
-}
-
 variable "account" {}
 
 variable "region" {}


### PR DESCRIPTION
Not all resources were disabled. This causes an issue where the S3
bucker and info modules are invoked when enabled = false. This change is
simply to clean up the now unnecessary flags in this repo.