### PR TITLE
Inhibit td-agent startup during builds

### DIFF
--- a/nubis/puppet/files/kubernetes-startup
+++ b/nubis/puppet/files/kubernetes-startup
@@ -30,3 +30,7 @@ fi
 
 # Kick dnsmasq into shape
 systemctl restart dnsmasq
+
+# Make sure we start td-agent (it was disabled during the build)
+# We add a custom plugin during the build
+/etc/init.d/td-agent restart

--- a/nubis/puppet/logging.pp
+++ b/nubis/puppet/logging.pp
@@ -1,4 +1,6 @@
-include ::fluentd
+class { 'fluentd':
+  service_ensure => stopped
+}
 
 # Ugh
 if $::osfamily == 'redhat' {


### PR DESCRIPTION
Also add a restart line in the boot-time scripts

Fixes #82